### PR TITLE
Don't assume starting_point() and veh.global_pos3() return the same tripoint

### DIFF
--- a/tests/vehicle_efficiency.cpp
+++ b/tests/vehicle_efficiency.cpp
@@ -60,8 +60,9 @@ long test_efficiency( const vproto_id &veh_id, const ter_id &terrain, int reset_
 {
     clear_game( terrain );
 
-    const tripoint starting_point( 60, 60, 0 );
-    vehicle *veh_ptr = g->m.add_vehicle( veh_id, starting_point, -90, 0, 0 );
+    const tripoint map_starting_point( 60, 60, 0 );
+    vehicle *veh_ptr = g->m.add_vehicle( veh_id, map_starting_point, -90, 0, 0 );
+
     REQUIRE( veh_ptr != nullptr );
     if( veh_ptr == nullptr ) {
         return 0;
@@ -69,6 +70,7 @@ long test_efficiency( const vproto_id &veh_id, const ter_id &terrain, int reset_
 
     set_vehicle_fuel( veh_ptr, fuel_level );
     vehicle &veh = *veh_ptr;
+    const tripoint starting_point = veh.global_pos3();
     veh.tags.insert( "IN_CONTROL_OVERRIDE" );
     veh.engine_on = true;
     REQUIRE( veh.safe_velocity() > 0 );


### PR DESCRIPTION
In tests for https://github.com/CleverRaven/Cataclysm-DDA/pull/19974 I've noticed that most debug-added vehicles appear with controls on the same spot as the player, but some (do remember `apc`) are added with an offset.

Not sure if related, but adding these changes stopped `fire_truck` and `fire_engines` from appearing regularly. In fact, the only consistent remaining failure is "`scooter` on dirt". Perhaps because the other cases are too lax?..

Mighty anecdotal, maybe food for thought.

Haven't run many tests, about 50 or so in total (multi-core, simultaneous in batches).

Tangent: failed tests sometimes have identical world names, so results are not saved. To counter-act, I've staggered test launches. Also noticed that if world names are identical, then failures will be identical.

Ping https://github.com/CleverRaven/Cataclysm-DDA/pull/20007